### PR TITLE
Add OAuth 2.0 Authorization to make calls to Google Calendar API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 src/main/java/servlets/
-yt-key.txt
 target/
-secret.txt
 yt-key.txt
+secret.txt
 .vscode
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/
+secret.txt
+yt-key.txt
+.vscode
 .idea

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,27 @@
         <artifactId>appengine-api-1.0-sdk</artifactId>
         <version>1.9.59</version>
     </dependency>
-  </dependencies>
-
+    <!-- Google Calendar API -->
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>v3-rev20200610-1.30.9</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.3.2</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.json/json-simple -->
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+  </dependency>
   
-
+  </dependencies>
+  
   <build>
     <plugins>
       <!-- Provides `mvn package appengine:run` for local testing

--- a/src/main/java/com/google/sps/servlets/schedule/ScheduleHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/ScheduleHandlerServlet.java
@@ -36,11 +36,6 @@ import java.util.List;
 @WebServlet("/schedule-handler")
 public final class ScheduleHandlerServlet extends HttpServlet {
 
-  /** We want to GRAB all calendar ID's. */
-  @Override
-  public void init() {
-  }
-
   /** Read through all filters */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/google/sps/servlets/schedule/ScheduleHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/ScheduleHandlerServlet.java
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.List;
+
+
+/** Servlet that handles the schedule. */
+@WebServlet("/schedule-handler")
+public final class ScheduleHandlerServlet extends HttpServlet {
+
+  /** We want to GRAB all calendar ID's. */
+  @Override
+  public void init() {
+  }
+
+  /** Read through all filters */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+    System.out.println("You're on the ScheduleHandler Servlet!");
+    response.setContentType("text/html");
+    response.getWriter().println("<h2>You have successfully authorized the app! And we can now make calls to the Google Calendar API!</h2>");
+
+    //response.sendRedirect("/schedule-generator"); 
+  }
+
+
+}

--- a/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
@@ -14,7 +14,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;  // Import the File class
 import java.io.FileNotFoundException;  // Import this class to handle errors
-import java.util.Scanner; // Import the Scanner class to read text files
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.InputStream;

--- a/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
@@ -1,0 +1,151 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.File;  // Import the File class
+import java.io.FileNotFoundException;  // Import this class to handle errors
+import java.util.Scanner; // Import the Scanner class to read text files
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+
+@WebServlet("/authorize")
+public class AuthorizationServlet extends HttpServlet {
+
+  // For RedirectURL, change the 3rd line in secret.txt
+  // Use if running in production:
+        // http://im-step.appspot.com/authorize
+
+  // Use if running locally on port 8080:
+        // https://8080-4271c707-a3a3-471c-bf8f-7ccb224d6188.us-central1.cloudshell.dev/authorize
+
+
+  private static String GOOGLE_CLIENT_ID = "";
+  private static String GOOGLE_CLIENT_SECRET = "";
+  private static String GOOGLE_REDIRECT_URL = "";
+  private static HTTP http = new HTTP();
+
+  public void init() {
+    ArrayList<String> secret = new ArrayList<String>();
+
+    try {
+      InputStream in = AuthorizationServlet.class.getResourceAsStream("/secret.txt");
+      BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+
+      while(reader.ready()) secret.add(reader.readLine());
+
+      GOOGLE_CLIENT_ID = secret.get(0);
+      GOOGLE_CLIENT_SECRET = secret.get(1);
+      GOOGLE_REDIRECT_URL = secret.get(2);
+      
+    } catch (Exception e) {
+      System.out.println("The secret file could not be found on your system! Please check path!");
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Handles the HTTP <code>GET</code> method.
+   *
+   * @param request servlet request
+   * @param response servlet response
+   * @throws ServletException if a servlet-specific error occurs
+   * @throws IOException if an I/O error occurs
+   */
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+    processRequest(request, response);
+  }
+
+
+  /**
+   * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
+   *
+   * @param request servlet request
+   * @param response servlet response
+   * @throws ServletException if a servlet-specific error occurs
+   * @throws IOException if an I/O error occurs
+   */
+  protected void processRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+    // If the user denied access, we get back an error, such as...
+    // error=access_denied&state=session%3Dpotatoes
+
+    if (req.getParameter("error") != null) {
+      System.out.println("We have recieved the error!");
+      resp.setContentType("text/html");
+      resp.getWriter().println("Something went wrong when we tried to get permission, please retry!");
+      return;
+    } else {
+
+      // Google returns a code that can be exchanged for an access token
+      String code = req.getParameter("code");
+
+      if (code == null) {
+        resp.setContentType("text/html");
+        resp.getWriter().println("<h1>The app must get permission from the '/request-permission' Servlet before making this request!</h1>");
+        return;
+      }
+
+      LinkedHashMap<String, String> params = new LinkedHashMap<String, String>();
+
+      params.put("code", code);
+      params.put("client_id", GOOGLE_CLIENT_ID);
+      params.put("client_secret", GOOGLE_CLIENT_SECRET);
+      params.put("redirect_uri", GOOGLE_REDIRECT_URL);
+      params.put("grant_type", "authorization_code");
+
+      // Grab the access token by post to Google
+      String body = http.post("https://accounts.google.com/o/oauth2/token", params);
+
+   // ex. returns
+   //   {
+   //       "access_token": "ya29.AHES6ZQS-BsKiPxdU_iKChTsaGCYZGcuqhm_A5bef8ksNoU",
+   //       "token_type": "Bearer",
+   //       "expires_in": 3600,
+   //       "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjA5ZmE5NmFjZWNkOGQyZWRjZmFiMjk0NDRhOTgyN2UwZmFiODlhYTYifQ.eyJpc3MiOiJhY2NvdW50cy5nb29nbGUuY29tIiwiZW1haWxfdmVyaWZpZWQiOiJ0cnVlIiwiZW1haWwiOiJhbmRyZXcucmFwcEBnbWFpbC5jb20iLCJhdWQiOiI1MDgxNzA4MjE1MDIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdF9oYXNoIjoieUpVTFp3UjVDX2ZmWmozWkNublJvZyIsInN1YiI6IjExODM4NTYyMDEzNDczMjQzMTYzOSIsImF6cCI6IjUwODE3MDgyMTUwMi5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImlhdCI6MTM4Mjc0MjAzNSwiZXhwIjoxMzgyNzQ1OTM1fQ.Va3kePMh1FlhT1QBdLGgjuaiI3pM9xv9zWGMA9cbbzdr6Tkdy9E-8kHqrFg7cRiQkKt4OKp3M9H60Acw_H15sV6MiOah4vhJcxt0l4-08-A84inI4rsnFn5hp8b-dJKVyxw1Dj1tocgwnYI03czUV3cVqt9wptG34vTEcV3dsU8",
+   //       "refresh_token": "1/Hc1oTSLuw7NMc3qSQMTNqN6MlmgVafc78IZaGhwYS-o"
+   //   }
+
+      // Get access token from JSON and request info from Google
+      JSONObject jsonObject = http.parseJSON(body);
+
+      // Google tokens expire after an hour, but since we requested offline access we can get a new token without user involvement via the refresh token
+      String accessToken = (String) jsonObject.get("access_token");
+
+      // Store the access token in session. Now we have this access token across our servlets for about 30 minutes!
+      req.getSession().setAttribute("access_token", accessToken);
+
+      resp.sendRedirect("/schedule-handler"); 
+    }
+  }
+}

--- a/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
@@ -115,7 +115,7 @@ public class AuthorizationServlet extends HttpServlet {
         return;
       }
 
-      LinkedHashMap<String, String> params = new LinkedHashMap<String, String>();
+      HashMap<String, String> params = new HashMap<String, String>();
 
       params.put("code", code);
       params.put("client_id", GOOGLE_CLIENT_ID);

--- a/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
@@ -100,7 +100,7 @@ public class AuthorizationServlet extends HttpServlet {
     // error=access_denied&state=session%3Dpotatoes
 
     if (req.getParameter("error") != null) {
-      System.out.println("We have recieved the error!");
+      System.out.println("We have received the error!");
       resp.setContentType("text/html");
       resp.getWriter().println("Something went wrong when we tried to get permission, please retry!");
       return;

--- a/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/AuthorizationServlet.java
@@ -47,10 +47,10 @@ public class AuthorizationServlet extends HttpServlet {
         // https://8080-4271c707-a3a3-471c-bf8f-7ccb224d6188.us-central1.cloudshell.dev/authorize
 
 
-  private static String GOOGLE_CLIENT_ID = "";
-  private static String GOOGLE_CLIENT_SECRET = "";
-  private static String GOOGLE_REDIRECT_URL = "";
-  private static HTTP http = new HTTP();
+  private String GOOGLE_CLIENT_ID = "";
+  private String GOOGLE_CLIENT_SECRET = "";
+  private String GOOGLE_REDIRECT_URL = "";
+  private HTTP http = new HTTP();
 
   public void init() {
     ArrayList<String> secret = new ArrayList<String>();

--- a/src/main/java/com/google/sps/servlets/schedule/auth/RequestPermissionServlet.java
+++ b/src/main/java/com/google/sps/servlets/schedule/auth/RequestPermissionServlet.java
@@ -1,0 +1,125 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.File;  // Import the File class
+import java.io.FileNotFoundException;  // Import this class to handle errors
+import java.util.Scanner; // Import the Scanner class to read text files
+
+
+@WebServlet("/request-permission")
+public class RequestPermissionServlet extends HttpServlet {
+
+    // For RedirectURL, change the 3rd line in secret.txt 
+    // Use if running in production:
+        // http://im-step.appspot.com/authorize
+
+    // Use if running locally on port 8080:
+        // https://8080-4271c707-a3a3-471c-bf8f-7ccb224d6188.us-central1.cloudshell.dev/authorize
+
+    private static String GOOGLE_CLIENT_ID = "";
+    private static String GOOGLE_REDIRECT_URL = "";
+
+    // Get client ID
+    public void init() {
+        ArrayList<String> secret = new ArrayList<String>();
+
+        try {
+            InputStream in = RequestPermissionServlet.class.getResourceAsStream("/secret.txt");
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+      
+            while(reader.ready()) {
+                secret.add(reader.readLine());
+            }
+      
+            GOOGLE_CLIENT_ID = secret.get(0);
+            GOOGLE_REDIRECT_URL = secret.get(2);
+            
+          } catch (Exception e) {
+            System.out.println("The secret file could not be found on your system! Please check path!");
+            e.printStackTrace();
+          }
+    }
+
+
+  /**
+   * Handles the HTTP GET method.
+   *
+   * @param request servlet request
+   * @param response servlet response
+   * @throws ServletException if a servlet-specific error occurs
+   * @throws IOException if an I/O error occurs
+   */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+  /**
+   * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
+   *
+   * @param request servlet request
+   * @param response servlet response
+   * @throws ServletException if a servlet-specific error occurs
+   * @throws IOException if an I/O error occurs
+   */
+  protected void processRequest(HttpServletRequest req, HttpServletResponse resp)
+    throws ServletException, IOException {
+        String scopes = "https://www.googleapis.com/auth/calendar";
+
+        StringBuilder oauthUrl = new StringBuilder();
+        oauthUrl.append("https://accounts.google.com/o/oauth2/v2/auth")
+            .append("?scope=").append(scopes)  // Scope is the api permissions we are requesting
+            .append("&access_type=offline")  // We can have access to the user's permission offline
+            .append("&include_granted_scopes=true")
+            .append("&response_type=code")  
+            .append("&state=state_parameter_passthrough_value")
+            .append("&redirect_uri=").append(GOOGLE_REDIRECT_URL) // This is the servlet that google redirects to after successfully authorization
+            .append("&client_id=").append(GOOGLE_CLIENT_ID) // This is the client id from the api console registration
+            .append("&approval_prompt=force"); // This requires them to verify which account to use, if they are already signed in
+        
+        try { 
+            resp.sendRedirect(oauthUrl.toString());
+        } catch (Exception e) {
+            System.out.println("Failed to ask the user access to their permissions because of: " + e);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/google/sps/servlets/schedule/util/HTTP.java
+++ b/src/main/java/com/google/sps/servlets/schedule/util/HTTP.java
@@ -1,0 +1,133 @@
+package com.google.sps.servlets;
+
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.entity.StringEntity;
+
+import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+public class HTTP {
+  private static Boolean accessTokenReceived = false;
+
+  // makes a GET request to url and returns body as a string
+  public String get(String url) throws ClientProtocolException, IOException {
+    return execute(new HttpGet(url));
+  }
+
+  // makes a POST request to url with form parameters and returns body as a string
+  public String post(String url, Map<String, String> formParameters) throws ClientProtocolException, IOException {
+    HttpPost request = new HttpPost(url);
+
+    if (accessTokenReceived) {
+      System.out.println("Recieved! <=======>");
+      request.setHeader("Accept", "application/json");
+      request.setHeader("Content-type", "application/json");
+    }
+
+    List<NameValuePair> nvps = new ArrayList<NameValuePair>();
+
+    for (String key : formParameters.keySet()) {
+      nvps.add(new BasicNameValuePair(key, formParameters.get(key)));
+    }
+
+    request.setEntity(new UrlEncodedFormEntity(nvps));
+
+    return execute(request);
+  }
+
+  public JSONObject postWithData(DefaultHttpClient httpClient, HttpPost postRequest, String json) {
+    HttpResponse response = null;
+    try {
+      StringEntity input = new StringEntity(json);
+      input.setContentType("application/json");
+      postRequest.setEntity(input);
+
+      response = httpClient.execute(postRequest);
+
+      if (response.getStatusLine().getStatusCode() != 200) {
+        HttpEntity entity = response.getEntity();
+        String body = EntityUtils.toString(entity);
+
+        throw new RuntimeException("Expected 200 but got " + response.getStatusLine().getStatusCode() + ", with body " + body);
+      }
+    } catch (Exception e) {
+      System.out.println("Something went wrong!" + e);
+    }
+
+    return responseToJSON(response);
+  }
+
+  // makes request and checks response code for 200
+  public String execute(HttpRequestBase request) throws ClientProtocolException, IOException {
+    HttpClient httpClient = new DefaultHttpClient();
+    HttpResponse response = httpClient.execute(request);
+
+    HttpEntity entity = response.getEntity();
+    String body = EntityUtils.toString(entity);
+
+    if (response.getStatusLine().getStatusCode() != 200) {
+      throw new RuntimeException("Expected 200 but got " + response.getStatusLine().getStatusCode() + ", with body " + body);
+    }
+
+    // Quick check to see if we get the code back. After our first request we want to be able to SEND JSON request!
+    JSONObject jsonObject = parseJSON(body);
+    String accessToken = (String) jsonObject.get("access_token");
+    if (accessToken != null) accessTokenReceived = true;
+    
+
+    return body;
+  }
+
+
+  // ======================== // Utility functions // =============================== //
+
+  // Turns string into a JSON Object that we can interact with
+  public JSONObject parseJSON(String json) {
+    JSONObject jsonObject = null;
+
+    try {
+      jsonObject = (JSONObject) new JSONParser().parse(json);
+    } catch (ParseException e) {
+      throw new RuntimeException("Unable to parse json because of: " + e);
+    }
+
+    return jsonObject;
+
+  }
+
+
+
+  // TODO: You could just add this to postWithData, see if you need this with anything else
+  // Turn response that we get from server into JSON. So that we can get data back.
+  public JSONObject responseToJSON(HttpResponse response) {
+    HttpEntity entity = response.getEntity();
+    String body = "";
+    try {
+      body = EntityUtils.toString(entity);
+    } catch (Exception e) {
+      System.out.println("There was an error with trying to turn the response back to JSON! " + e);
+    }
+
+    return parseJSON(body);
+  }
+}

--- a/src/main/java/com/google/sps/servlets/schedule/util/HTTP.java
+++ b/src/main/java/com/google/sps/servlets/schedule/util/HTTP.java
@@ -38,12 +38,6 @@ public class HTTP {
   public String post(String url, Map<String, String> formParameters) throws ClientProtocolException, IOException {
     HttpPost request = new HttpPost(url);
 
-    if (accessTokenReceived) {
-      System.out.println("Recieved! <=======>");
-      request.setHeader("Accept", "application/json");
-      request.setHeader("Content-type", "application/json");
-    }
-
     List<NameValuePair> nvps = new ArrayList<NameValuePair>();
 
     for (String key : formParameters.keySet()) {


### PR DESCRIPTION
Adds ability to make calls to the Google Calendar API by getting the access token.

NOTE: 
You MUST have the secret.txt file and the path must be located in: src/main/resources/secret.txt. 
It contains in order on separate lines the...
GOOGLE_CLIENT_ID
GOOGLE_CLIENT_SECRET
GOOGLE_REDIRECT_URL* 

The Google Redirect URL must be either:
*For local dev on port 8080 this is: https://8080-4271c707-a3a3-471c-bf8f-7ccb224d6188.us-central1.cloudshell.dev/authorize 
*For prod this is: http://im-step.appspot.com/authorize

To use: Navigate to /request-permission

@chrisc94 @maricarol3355 @cjhbh3 @ptai7 

